### PR TITLE
Add username & password in mail task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ notify_message: "[{{inventory_hostname}}] has been updated by {{ansible_ssh_user
 notify_mail_to: ""
 notify_mail_cc: ""
 notify_mail_from: ansible@{{inventory_hostname}}
+notify_mail_username: ""
+notify_mail_password: ""
 notify_mail_host: localhost
 notify_mail_port: 25
 notify_mail_attach: ""

--- a/tasks/mail.yml
+++ b/tasks/mail.yml
@@ -8,6 +8,8 @@
 - name: Send email notify
   mail:
     to="{{notify_mail_to}}"
+    username="{{notify_mail_username}}"
+    password="{{notify_mail_password}}"
     host="{{notify_mail_host}}"
     port="{{notify_mail_port}}"
     subject="{{notify_message}}"


### PR DESCRIPTION
As of Ansible 1.9 the mail module enables SMTP authentication.
